### PR TITLE
[feat] 유저 상세 정보 조회 API

### DIFF
--- a/src/main/java/org/festimate/api/controller/UserController.java
+++ b/src/main/java/org/festimate/api/controller/UserController.java
@@ -2,13 +2,11 @@ package org.festimate.api.controller;
 
 import jakarta.validation.Valid;
 import org.festimate.api.dto.request.SignUpRequest;
+import org.festimate.api.dto.response.UserDetailResponse;
 import org.festimate.api.dto.response.UserResponse;
 import org.festimate.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/festimate/v1")
@@ -23,7 +21,15 @@ public class UserController {
     public ResponseEntity<UserResponse> signup(
             @Valid @RequestBody SignUpRequest signupRequest
     ) {
-        Long memberId = userService.signupUser(signupRequest.getUsername(), signupRequest.getNickname(), signupRequest.getAge(), signupRequest.getGender(), signupRequest.getSchool(), signupRequest.getHeight(), signupRequest.getMbti(), signupRequest.getAppearanceList());
-        return ResponseEntity.ok(new UserResponse(memberId));
+        Long userId = userService.signupUser(signupRequest.getUsername(), signupRequest.getNickname(), signupRequest.getAge(), signupRequest.getGender(), signupRequest.getSchool(), signupRequest.getHeight(), signupRequest.getMbti(), signupRequest.getAppearanceList());
+        return ResponseEntity.ok(new UserResponse(userId));
+    }
+
+    @GetMapping("/user-detail")
+    public ResponseEntity<UserDetailResponse> getUserDetails(
+            @Valid @RequestHeader("userId") Long userId
+    ) {
+        UserDetailResponse userDetail = userService.getUserDetailById(userId);
+        return ResponseEntity.ok(userDetail);
     }
 }

--- a/src/main/java/org/festimate/api/dto/response/ErrorCode.java
+++ b/src/main/java/org/festimate/api/dto/response/ErrorCode.java
@@ -4,6 +4,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "e4000", "유효하지 않은 요청입니다."),
     INVALID_INPUT_HTTP(405, "e4050", "잘못된 HTTP method 요청입니다."),
     INVALID_INPUT_USER_DUPLICATE(409, "e4090", "이미 존재하는 회원입니다."),
+    USER_NOT_FOUND(409, "e4091", "존재하지 않은 회원입니다."),
     INTERNAL_SERVER_ERROR(500, "e5000", "서버 내부 오류입니다.");
 
     private final int code;

--- a/src/main/java/org/festimate/api/dto/response/UserDetailResponse.java
+++ b/src/main/java/org/festimate/api/dto/response/UserDetailResponse.java
@@ -1,0 +1,7 @@
+package org.festimate.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 포함하지 않음
+public record UserDetailResponse(String nickname, String school) {
+}

--- a/src/main/java/org/festimate/api/dto/response/UserResponse.java
+++ b/src/main/java/org/festimate/api/dto/response/UserResponse.java
@@ -1,4 +1,4 @@
 package org.festimate.api.dto.response;
 
-public record UserResponse(Long UserId) {
+public record UserResponse(Long userId) {
 }

--- a/src/main/java/org/festimate/service/UserService.java
+++ b/src/main/java/org/festimate/service/UserService.java
@@ -1,6 +1,7 @@
 package org.festimate.service;
 
 import org.festimate.api.dto.response.ErrorCode;
+import org.festimate.api.dto.response.UserDetailResponse;
 import org.festimate.api.exception.CustomException;
 import org.festimate.domain.entity.Appearance;
 import org.festimate.domain.entity.User;
@@ -31,4 +32,17 @@ public class UserService {
         return userRepository.save(newUser).getId();
     }
 
+    // 유저 정보 조회 (닉네임, 학교)
+    public UserDetailResponse getUserDetailById(Long userId) {
+        // 유저 존재 여부 확인
+        User user = findByIdOrThrow(userId);
+        return new UserDetailResponse(user.getNickname(), user.getSchool());
+    }
+
+    // 닉네임으로 유저 조회
+    public User findByIdOrThrow(final Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **관련 이슈**
- closed #5 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
URI : /festimate/v1/user-detail
유저 상세 정보 조회 API 를 만들었습니다~!

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
1️⃣ Request Header
`
{
    "userId" : 1
}
`

2️⃣ Response Body
`
{
    "nickname": "아기고양이",
    "school": "가톨릭대학교",
}
`

3️⃣ 구현된 에러 검사 기능
- [ ] userId를 통한 유저 정보 조회 (가입된 유저가 아닐 시에는 에러 발생)
따로 로그인 기능을 제시하지 않고 있기 때문에,
회원가입시 반환한 userId를 로컬에 저장하여
해당 API 호출 시 헤더로 보내면 검사하는 방식입니다~!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|유저 상세 정보 조회|<img width="538" alt="image" src="https://github.com/user-attachments/assets/0ce66476-6a4b-4220-90ab-565d29692eda">|
